### PR TITLE
schemas add

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,93 @@
+"""
+Pydantic Schemas for Amaejozu Application
+Based on app/models
+"""
+
+from .base import BaseSchema
+from .user import UserBase, UserCreate, UserUpdate, UserResponse
+from .category import CategoryBase, CategoryCreate, CategoryUpdate, CategoryResponse
+from .brand import BrandBase, BrandCreate, BrandUpdate, BrandResponse
+from .product import (
+    ProductBase,
+    ProductCreate,
+    ProductUpdate,
+    ProductResponse,
+    ProductWithBrandCategory,
+)
+from .price_history import PriceHistoryBase, PriceHistoryCreate, PriceHistoryResponse
+from .watchlist import (
+    WatchlistBase,
+    WatchlistCreate,
+    WatchlistUpdate,
+    WatchlistResponse,
+    WatchlistWithProduct,
+)
+from .alert import AlertBase, AlertCreate, AlertResponse
+from .notification import (
+    NotificationBase,
+    NotificationCreate,
+    NotificationUpdate,
+    NotificationResponse,
+)
+from .brand_follow import (
+    BrandFollowBase,
+    BrandFollowCreate,
+    BrandFollowResponse,
+    BrandFollowWithBrand,
+)
+from .user_interest import (
+    UserInterestBase,
+    UserInterestCreate,
+    UserInterestResponse,
+    UserInterestWithCategory,
+)
+
+# Rebuild models with forward references
+ProductWithBrandCategory.model_rebuild()
+WatchlistWithProduct.model_rebuild()
+BrandFollowWithBrand.model_rebuild()
+UserInterestWithCategory.model_rebuild()
+
+__all__ = [
+    "BaseSchema",
+    "UserBase",
+    "UserCreate",
+    "UserUpdate",
+    "UserResponse",
+    "CategoryBase",
+    "CategoryCreate",
+    "CategoryUpdate",
+    "CategoryResponse",
+    "BrandBase",
+    "BrandCreate",
+    "BrandUpdate",
+    "BrandResponse",
+    "ProductBase",
+    "ProductCreate",
+    "ProductUpdate",
+    "ProductResponse",
+    "ProductWithBrandCategory",
+    "PriceHistoryBase",
+    "PriceHistoryCreate",
+    "PriceHistoryResponse",
+    "WatchlistBase",
+    "WatchlistCreate",
+    "WatchlistUpdate",
+    "WatchlistResponse",
+    "WatchlistWithProduct",
+    "AlertBase",
+    "AlertCreate",
+    "AlertResponse",
+    "NotificationBase",
+    "NotificationCreate",
+    "NotificationUpdate",
+    "NotificationResponse",
+    "BrandFollowBase",
+    "BrandFollowCreate",
+    "BrandFollowResponse",
+    "BrandFollowWithBrand",
+    "UserInterestBase",
+    "UserInterestCreate",
+    "UserInterestResponse",
+    "UserInterestWithCategory",
+]

--- a/app/schemas/alert.py
+++ b/app/schemas/alert.py
@@ -1,0 +1,28 @@
+"""Alert schemas"""
+from datetime import datetime
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+
+class AlertBase(BaseSchema):
+    """Base alert schema"""
+    watch_item_id: str = Field(..., max_length=36)
+    alert_type: str = Field(..., max_length=50)
+    old_price: int
+    new_price: int
+    drop_rate: float
+
+
+class AlertCreate(AlertBase):
+    """Schema for creating an alert"""
+    id: str = Field(..., max_length=36)
+    triggered_at: datetime
+
+
+class AlertResponse(AlertBase):
+    """Schema for alert response"""
+    id: str
+    triggered_at: datetime
+    created_at: datetime

--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -1,0 +1,7 @@
+"""Base schema configuration"""
+from pydantic import BaseModel, ConfigDict
+
+
+class BaseSchema(BaseModel):
+    """Base schema with common configuration"""
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/brand.py
+++ b/app/schemas/brand.py
@@ -1,0 +1,33 @@
+"""Brand schemas"""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+
+class BrandBase(BaseSchema):
+    """Base brand schema"""
+    name: str = Field(..., max_length=255)
+    shop_code: str = Field(..., max_length=100)
+    logo_url: Optional[str] = Field(None, max_length=500)
+
+
+class BrandCreate(BrandBase):
+    """Schema for creating a brand"""
+    id: str = Field(..., max_length=36)
+
+
+class BrandUpdate(BaseSchema):
+    """Schema for updating a brand"""
+    name: Optional[str] = Field(None, max_length=255)
+    shop_code: Optional[str] = Field(None, max_length=100)
+    logo_url: Optional[str] = Field(None, max_length=500)
+
+
+class BrandResponse(BrandBase):
+    """Schema for brand response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime

--- a/app/schemas/brand_follow.py
+++ b/app/schemas/brand_follow.py
@@ -1,0 +1,35 @@
+"""BrandFollow schemas"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+if TYPE_CHECKING:
+    from .brand import BrandResponse
+
+
+class BrandFollowBase(BaseSchema):
+    """Base brand follow schema"""
+    user_id: str = Field(..., max_length=36)
+    brand_id: str = Field(..., max_length=36)
+
+
+class BrandFollowCreate(BrandFollowBase):
+    """Schema for creating a brand follow"""
+    id: str = Field(..., max_length=36)
+
+
+class BrandFollowResponse(BrandFollowBase):
+    """Schema for brand follow response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class BrandFollowWithBrand(BrandFollowResponse):
+    """Schema for brand follow response with brand details"""
+    brand: Optional[BrandResponse] = None

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -1,0 +1,33 @@
+"""Category schemas"""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+
+class CategoryBase(BaseSchema):
+    """Base category schema"""
+    name: str = Field(..., max_length=255)
+    slug: str = Field(..., max_length=100)
+    sort_order: int = 0
+
+
+class CategoryCreate(CategoryBase):
+    """Schema for creating a category"""
+    id: str = Field(..., max_length=36)
+
+
+class CategoryUpdate(BaseSchema):
+    """Schema for updating a category"""
+    name: Optional[str] = Field(None, max_length=255)
+    slug: Optional[str] = Field(None, max_length=100)
+    sort_order: Optional[int] = None
+
+
+class CategoryResponse(CategoryBase):
+    """Schema for category response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime

--- a/app/schemas/notification.py
+++ b/app/schemas/notification.py
@@ -1,0 +1,34 @@
+"""Notification schemas"""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+
+class NotificationBase(BaseSchema):
+    """Base notification schema"""
+    user_id: str = Field(..., max_length=36)
+    alert_id: str = Field(..., max_length=36)
+    title: str = Field(..., max_length=255)
+    message: str
+    channel: str = Field(..., max_length=50)
+    is_read: bool = False
+    sent_at: datetime
+
+
+class NotificationCreate(NotificationBase):
+    """Schema for creating a notification"""
+    id: str = Field(..., max_length=36)
+
+
+class NotificationUpdate(BaseSchema):
+    """Schema for updating a notification"""
+    is_read: Optional[bool] = None
+
+
+class NotificationResponse(NotificationBase):
+    """Schema for notification response"""
+    id: str
+    created_at: datetime

--- a/app/schemas/price_history.py
+++ b/app/schemas/price_history.py
@@ -1,0 +1,25 @@
+"""PriceHistory schemas"""
+from datetime import datetime
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+
+class PriceHistoryBase(BaseSchema):
+    """Base price history schema"""
+    product_id: str = Field(..., max_length=36)
+    price: int
+    discount_rate: float = 0.0
+    observed_at: datetime
+
+
+class PriceHistoryCreate(PriceHistoryBase):
+    """Schema for creating a price history"""
+    id: str = Field(..., max_length=36)
+
+
+class PriceHistoryResponse(PriceHistoryBase):
+    """Schema for price history response"""
+    id: str
+    created_at: datetime

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -1,0 +1,70 @@
+"""Product schemas"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+if TYPE_CHECKING:
+    from .brand import BrandResponse
+    from .category import CategoryResponse
+
+
+class ProductBase(BaseSchema):
+    """Base product schema"""
+    brand_id: str = Field(..., max_length=36)
+    category_id: str = Field(..., max_length=36)
+    rakuten_item_code: str = Field(..., max_length=100)
+    name: str = Field(..., max_length=500)
+    image_url: Optional[str] = Field(None, max_length=1000)
+    product_url: str = Field(..., max_length=1000)
+    affiliate_url: Optional[str] = Field(None, max_length=1000)
+    current_price: int
+    original_price: int
+    lowest_price: Optional[int] = None
+    discount_rate: float = 0.0
+    is_on_sale: bool = False
+    checked_at: datetime
+    review_score: Optional[int] = None
+    review_count: Optional[int] = None
+    ranking: Optional[int] = None
+    ranking_prev: Optional[int] = None
+
+
+class ProductCreate(ProductBase):
+    """Schema for creating a product"""
+    id: str = Field(..., max_length=36)
+
+
+class ProductUpdate(BaseSchema):
+    """Schema for updating a product"""
+    name: Optional[str] = Field(None, max_length=500)
+    image_url: Optional[str] = Field(None, max_length=1000)
+    product_url: Optional[str] = Field(None, max_length=1000)
+    affiliate_url: Optional[str] = Field(None, max_length=1000)
+    current_price: Optional[int] = None
+    original_price: Optional[int] = None
+    lowest_price: Optional[int] = None
+    discount_rate: Optional[float] = None
+    is_on_sale: Optional[bool] = None
+    checked_at: Optional[datetime] = None
+    review_score: Optional[int] = None
+    review_count: Optional[int] = None
+    ranking: Optional[int] = None
+    ranking_prev: Optional[int] = None
+
+
+class ProductResponse(ProductBase):
+    """Schema for product response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProductWithBrandCategory(ProductResponse):
+    """Schema for product response with brand and category details"""
+    brand: Optional[BrandResponse] = None
+    category: Optional[CategoryResponse] = None

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,36 @@
+"""User schemas"""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import EmailStr, Field
+
+from .base import BaseSchema
+
+
+class UserBase(BaseSchema):
+    """Base user schema"""
+    email: EmailStr
+    nickname: str = Field(..., max_length=100)
+    device_token: Optional[str] = Field(None, max_length=255)
+    push_enabled: bool = False
+    email_enabled: bool = True
+
+
+class UserCreate(UserBase):
+    """Schema for creating a user"""
+    id: str = Field(..., max_length=36)
+
+
+class UserUpdate(BaseSchema):
+    """Schema for updating a user"""
+    nickname: Optional[str] = Field(None, max_length=100)
+    device_token: Optional[str] = Field(None, max_length=255)
+    push_enabled: Optional[bool] = None
+    email_enabled: Optional[bool] = None
+
+
+class UserResponse(UserBase):
+    """Schema for user response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime

--- a/app/schemas/user_interest.py
+++ b/app/schemas/user_interest.py
@@ -1,0 +1,35 @@
+"""UserInterest schemas"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+if TYPE_CHECKING:
+    from .category import CategoryResponse
+
+
+class UserInterestBase(BaseSchema):
+    """Base user interest schema"""
+    user_id: str = Field(..., max_length=36)
+    category_id: str = Field(..., max_length=36)
+
+
+class UserInterestCreate(UserInterestBase):
+    """Schema for creating a user interest"""
+    id: str = Field(..., max_length=36)
+
+
+class UserInterestResponse(UserInterestBase):
+    """Schema for user interest response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class UserInterestWithCategory(UserInterestResponse):
+    """Schema for user interest response with category details"""
+    category: Optional[CategoryResponse] = None

--- a/app/schemas/watchlist.py
+++ b/app/schemas/watchlist.py
@@ -1,0 +1,43 @@
+"""Watchlist schemas"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+
+from .base import BaseSchema
+
+if TYPE_CHECKING:
+    from .product import ProductResponse
+
+
+class WatchlistBase(BaseSchema):
+    """Base watchlist schema"""
+    user_id: str = Field(..., max_length=36)
+    product_id: str = Field(..., max_length=36)
+    target_price: Optional[int] = None
+    notify_any_drop: bool = True
+
+
+class WatchlistCreate(WatchlistBase):
+    """Schema for creating a watchlist item"""
+    id: str = Field(..., max_length=36)
+
+
+class WatchlistUpdate(BaseSchema):
+    """Schema for updating a watchlist item"""
+    target_price: Optional[int] = None
+    notify_any_drop: Optional[bool] = None
+
+
+class WatchlistResponse(WatchlistBase):
+    """Schema for watchlist response"""
+    id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class WatchlistWithProduct(WatchlistResponse):
+    """Schema for watchlist response with product details"""
+    product: Optional[ProductResponse] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ alembic==1.17.2
 # Data Validation
 pydantic==2.12.5
 pydantic-settings==2.7.0
+email-validator==2.2.0
 
 # Environment Variables
 python-dotenv==1.0.1


### PR DESCRIPTION
  ---                                                                                           
  Summary                                                                                       
                                                                                                
  - app/modelsに対応するPydanticスキーマを追加                                                  
  - 各モデル（User, Category, Brand, Product, PriceHistory, Watchlist, Alert, Notification,     
  BrandFollow, UserInterest）に対してBase/Create/Update/Responseスキーマを実装                  
                                                                                                
  Changes                                                                                       
                                                                                                
  - app/schemas/ ディレクトリを新規作成                                                         
  - 各エンティティのCRUD操作に対応するスキーマを定義                                            
  - email-validator を依存関係に追加                                                            
                                                                                                
  Test plan                                                                                     
                                                                                                
  - python -c "from app.schemas import *; print('All schemas imported successfully!')"でインポートエラーがないことを確認                                
                                                                                                
  ---     