### PR TITLE
fix: remove unused python-jose dependencyfix: remove unused python-jose dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ requests==2.32.3
 cachetools==5.5.0
 
 # Security
-python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.20
 pyjwt==2.10.1


### PR DESCRIPTION
## 概要
未使用のpython-joseパッケージをrequirements.txtから削除

## 理由
- python-joseはコード内で一切importされていない
- JWT操作はすべてpyjwtを使用している
- python-joseにHigh深刻度の脆弱性が2件存在

## 対応するSnyk指摘
- High: CWE-409 Improper Handling of Highly Compressed Data (CVSS 7.5)
- High: CWE-347 Improper Verification of Cryptographic Signature (CVSS 7.4)

## 影響範囲
- 未使用パッケージの削除のため、API動作への影響なし