### PR TITLE
)fix: remove hardcoded passwords from API example schemas

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -52,7 +52,7 @@ class LoginRequest(BaseModel):
 
     model_config = ConfigDict(
         json_schema_extra={
-            "example": {"email": "user@example.com", "password": "password123"}
+            "example": {"email": "user@example.com", "password": "**********"}
         }
     )
 
@@ -65,7 +65,7 @@ class SignupRequest(BaseModel):
 
     model_config = ConfigDict(
         json_schema_extra={
-            "example": {"email": "newuser@example.com", "password": "securepass123"}
+            "example": {"email": "newuser@example.com", "password": "**********"}
         }
     )
 

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -48,8 +48,8 @@ class PasswordChangeRequest(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "current_password": "currentpass123",
-                "new_password": "newsecurepass456"
+                "current_password": "**********",
+                "new_password": "**********"
             }
         }
     )


### PR DESCRIPTION
## 概要
APIドキュメント（Swagger UI）のexampleからハードコードされたパスワードを除去

## 変更内容
- app/auth.py: LoginRequest、SignupRequestのexampleを修正
- app/routers/user.py: PasswordChangeRequestのexampleを修正

## 対応するSnyk指摘
- Medium: CWE-798 Use of Hardcoded Passwords × 4件

## 影響範囲
- Swagger UIのサンプル値表示のみ
- API動作への影響なし